### PR TITLE
Fix download_model.sh by removing trailing forward-flash

### DIFF
--- a/download_model.sh
+++ b/download_model.sh
@@ -4,5 +4,5 @@ mkdir models/$model
 
 # TODO: gsutil rsync -r gs://gpt-2/models/ models/
 for filename in checkpoint encoder.json hparams.json model.ckpt.data-00000-of-00001 model.ckpt.index model.ckpt.meta vocab.bpe; do
-  gsutil cp gs://gpt-2/models/$model/$filename models/$model/
+  gsutil cp gs://gpt-2/models/$model/$filename models/$model
 done


### PR DESCRIPTION
Running `download_model.sh` as-is results in:

<img width="506" alt="screen shot 2019-02-14 at 10 58 21 am" src="https://user-images.githubusercontent.com/2179708/52810661-ea1b9c00-3047-11e9-91e3-af378d08388d.png">

Removing the trailing forward-slash fixes the issue.