### PR TITLE
Improve environment setup & fix path errors & exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,23 @@ See more details in our [blog post](https://blog.openai.com/better-language-mode
 ## Installation
 
 Download the model data (needs [gsutil](https://cloud.google.com/storage/docs/gsutil_install)):
-```
-sh download_model.sh 117M
+```bash
+./download_model.sh 117M
 ```
 
-Install python packages:
+Create virtual environment with [miniconda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html#regular-installation):
+```bash
+conda create -y -n gpt-2 python=3.6
 ```
-pip3 install -r requirements.txt
+
+And activate it:
+```bash
+conda activate gpt-2
+```
+
+Then install python packages:
+```bash
+pip install -r requirements.txt
 ```
 
 ## Unconditional sample generation
@@ -24,12 +34,13 @@ pip3 install -r requirements.txt
 | --- |
 
 To generate unconditional samples from the small model:
+```bash
+python generate_unconditional_samples.py | tee samples
 ```
-python3 src/generate_unconditional_samples.py | tee samples
-```
+
 There are various flags for controlling the samples:
-```
-python3 src/generate_unconditional_samples.py --top_k 40 --temperature 0.7 | tee samples
+```bash
+python generate_unconditional_samples.py --top_k 40 --temperature 0.7 | tee samples
 ```
 
 While we have not yet released GPT-2 itself, you can see some unconditional samples from it (with default settings of temperature 1 and no truncation) in `gpt2-samples.txt`.
@@ -37,8 +48,8 @@ While we have not yet released GPT-2 itself, you can see some unconditional samp
 ## Conditional sample generation
 
 To give the model custom prompts, you can use:
-```
-python3 src/interactive_conditional_samples.py
+```bash
+python interactive_conditional_samples.py
 ```
 
 ## Future work
@@ -46,3 +57,4 @@ python3 src/interactive_conditional_samples.py
 We may release code for evaluating the models on various benchmarks.
 
 We are still considering release of the larger models.
+

--- a/download_model.sh
+++ b/download_model.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 model=$1
 
 mkdir -p models/$model

--- a/generate_unconditional_samples.py
+++ b/generate_unconditional_samples.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import fire
 import json
 import os

--- a/interactive_conditional_samples.py
+++ b/interactive_conditional_samples.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import fire
 import json
 import os

--- a/src/sample.py
+++ b/src/sample.py
@@ -1,6 +1,6 @@
 import tensorflow as tf
 
-import model
+from src import model
 
 def top_k_logits(logits, k):
     if k == 0:


### PR DESCRIPTION
Added instructions on creating a virtual environment with `conda`.
Obviates the need to use `python3/pip3`. Also ensures that the
requirements installation will work: there won't be any conflicts
in the environment.

Fixed the path import errors by adding `src/__init__.py`, explicitly
importing: `from src import ..`, and by moving the executable Python
scripts to the project's root. Updated README documentation too.

Made the `download_model.sh` script exectuable and changed it to
use the first `bash` executable found on the system's `$PATH`.
Additionally, made the Python scripts _not_ executable (they
should be run with `python ...` at any rate).