### PR TITLE
Add a Dockerfile and ignore example artifacts

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,12 @@
+FROM tensorflow/tensorflow:1.12.0-py3
+
+ENV LANG=C.UTF-8
+RUN mkdir /gpt-2 
+WORKDIR /gpt-2
+COPY requirements.txt download_model.sh /gpt-2/
+RUN apt-get update && \
+    apt-get install -y curl && \
+    sh download_model.sh 117M
+RUN pip3 install -r requirements.txt
+
+ADD . /gpt-2

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,21 @@
+FROM tensorflow/tensorflow:1.12.0-gpu-py3
+
+# nvidia-docker 1.0
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
+
+# nvidia-container-runtime
+ENV NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility \
+    NVIDIA_REQUIRE_CUDA="cuda>=8.0" \
+    LANG=C.UTF-8
+
+RUN mkdir /gpt-2
+WORKDIR /gpt-2
+COPY requirements.txt download_model.sh /gpt-2/
+RUN apt-get update && \
+    apt-get install -y curl && \
+    sh download_model.sh 117M
+RUN pip3 install -r requirements.txt
+
+ADD . /gpt-2

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Git clone this repository, and `cd` into directory for remaining commands
 git clone https://github.com/openai/gpt-2.git && cd gpt-2
 ```
 
+### Native Installation
+
 Download the model data
 ```
 sh download_model.sh 117M
@@ -32,6 +34,21 @@ pip3 install tensorflow-gpu==1.12.0
 Install other python packages:
 ```
 pip3 install -r requirements.txt
+```
+
+### Docker Installation
+
+Build the Dockerfile and tag the created image as `gpt-2`:
+```
+docker build --tag gpt-2 -f Dockerfile.gpu . # or Dockerfile.cpu
+```
+
+Start an interactive bash session from the `gpt-2` docker image.
+
+You can opt to use the `--runtime=nvidia` flag if you have access to a NVIDIA GPU
+and a valid install of [nvidia-docker 2.0](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)).
+```
+docker run --runtime=nvidia -it gpt-2 bash
 ```
 
 ## Usage


### PR DESCRIPTION
If you'd like, here's a Dockerfile to toss up as an alternate installation method. 

Also quickly gitignored the `samples` file and `core` file generated by running the example in the README. 