### PR TITLE
Fetch model files using curl directly from GCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See more details in our [blog post](https://blog.openai.com/better-language-mode
 
 ## Installation
 
-Download the model data (needs [gsutil](https://cloud.google.com/storage/docs/gsutil_install)):
+Download the model data
 ```
 sh download_model.sh 117M
 ```

--- a/download_model.sh
+++ b/download_model.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 if [ "$#" -ne 1 ]; then
     echo "You must enter the model name as a parameter, e.g.: sh download_model.sh 117M"
     exit 1
@@ -9,5 +11,7 @@ mkdir -p models/$model
 
 # TODO: gsutil rsync -r gs://gpt-2/models/ models/
 for filename in checkpoint encoder.json hparams.json model.ckpt.data-00000-of-00001 model.ckpt.index model.ckpt.meta vocab.bpe; do
-  gsutil cp gs://gpt-2/models/$model/$filename models/$model
+  fetch=$model/$filename
+  echo "Fetching $fetch"
+  curl --output models/$fetch https://storage.googleapis.com/gpt-2/models/$fetch
 done


### PR DESCRIPTION
Since each publicly accessible GCS bucket is reachable via `storage.googleapis.com`, there is no need for gsutil to be present for downloading files.