### PR TITLE
Better example parameters for conditional sample command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ While we have not yet released GPT-2 itself, you can see some unconditional samp
 
 To give the model custom prompts, you can use:
 ```
-python3 src/interactive_conditional_samples.py --top_k 40 --temperature 0.7
+python3 src/interactive_conditional_samples.py --top_k 40
 ```
 
 ## Future work

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ While we have not yet released GPT-2 itself, you can see some unconditional samp
 
 To give the model custom prompts, you can use:
 ```
-python3 src/interactive_conditional_samples.py
+python3 src/interactive_conditional_samples.py --top_k 40 --temperature 0.7
 ```
 
 ## Future work


### PR DESCRIPTION
This PR adds better initial parameters to the example conditional sample generation command in the docs.

The results are pretty poor in the interactive script with the default settings.  

Now, you'll get better results if you run the interactive samples using the example command from the README.