### PR TITLE
fixing requirements error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fire>=0.1.3
-tensorflow>=1.12
+tensorflow>=r1.12
 regex==2017.4.5


### PR DESCRIPTION
Was getting this when trying to install the requirements...  ``` Could not find a version that satisfies the requirement tensorflow>=1.2 (from -r requirements.txt (line 2)) (from versions: 1.12.0rc1, 1.12.0rc2)
No matching distribution found for tensorflow>=1.2 (from -r requirements.txt (line 2))```

Adding an 'r' in in front of the tensorflow version worked for me