### PR TITLE
fixed seed arg to ensure reproducibility in generate_unconditional_samples.py 

### DIFF
--- a/src/generate_unconditional_samples.py
+++ b/src/generate_unconditional_samples.py
@@ -17,9 +17,6 @@ def sample_model(
     temperature=1,
     top_k=0,
 ):
-    np.random.seed(seed)
-    tf.set_random_seed(seed)
-
     enc = encoder.get_encoder(model_name)
     hparams = model.default_hparams()
     with open(os.path.join('models', model_name, 'hparams.json')) as f:
@@ -31,6 +28,9 @@ def sample_model(
         raise ValueError("Can't get samples longer than window size: %s" % hparams.n_ctx)
 
     with tf.Session(graph=tf.Graph()) as sess:
+        np.random.seed(seed)
+        tf.set_random_seed(seed)
+
         output = sample.sample_sequence(
             hparams=hparams, length=length,
             start_token=enc.encoder['<|endoftext|>'],


### PR DESCRIPTION
Before, setting up `seed` flag with a value did not make any changes in the results, as noted in #58 

The reason was that the random seed needed to be within the `with tf.Session(tf.Graph())` scope (line 30 in updated version). I updated the file to reflect the change.

Now setting flag `seed` to a specific value ensures you get the same results everytime you run the code:
```
(p3env) Ignacios-MBP:gpt-2 iglopezfrancos$ python3 src/generate_unconditional_samples.py --top_k 40 --nsamples 1 --seed=1234 --length 10
======================================== SAMPLE 1 ========================================
1. It's okay to feel a little uncomfortable
(p3env) Ignacios-MBP:gpt-2 iglopezfrancos$ python3 src/generate_unconditional_samples.py --top_k 40 --nsamples 1 --seed=1234 --length 10
======================================== SAMPLE 1 ========================================
1. It's okay to feel a little uncomfortable
(p3env) Ignacios-MBP:gpt-2 iglopezfrancos$ python3 src/generate_unconditional_samples.py --top_k 40 --nsamples 1 --seed=1234
```

I suspect same issue occurs for  interactive_conditional_samples.py 

