### PR TITLE
add .gitattributes file to ensure files copied to docker container ha…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# convert to OS line endings on checkout, back to LF on commit
+* text=auto
+
+# ensure anything copied to the container has unix style line endings
+*.sh text eol=lf
+requirements.txt text eol=lf


### PR DESCRIPTION
On windows machines git defaults to cloning with windows style line breaks. This breaks the *.sh file, so we should ensure that all files copied to the docker container keep their unix style line endings.