### PR TITLE
WIP: Add chat example

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import fire
+import json
+import os
+import sys
+import numpy as np
+import tensorflow as tf
+
+import model, sample, encoder
+
+def interact_model(
+    model_name='117M',
+    seed=None,
+    nsamples=1,
+    batch_size=None,
+    length=70,
+    temperature=1,
+    top_k=0,
+    conversation="""
+you: hi
+her: hey
+you: i'm a human
+her: i'm a robot
+you: you ready?
+her: yes :)
+you: ok let's start chatting
+her: sure, what do you want to talk about?"""
+):
+
+    enc = encoder.get_encoder(model_name)
+    hparams = model.default_hparams()
+    with open(os.path.join('models', model_name, 'hparams.json')) as f:
+        hparams.override_from_dict(json.load(f))
+
+    if length is None:
+        length = hparams.n_ctx // 2
+    elif length > hparams.n_ctx:
+        raise ValueError("Can't get samples longer than window size: %s" % hparams.n_ctx)
+
+    length = 20
+    with tf.Session(graph=tf.Graph()) as sess:
+        np.random.seed(seed)
+        tf.set_random_seed(seed)
+        context = tf.placeholder(tf.int32, [1, None])
+        output = sample.sample_sequence(
+            hparams=hparams, length=length,
+            context=context,
+            batch_size=1,
+            temperature=temperature, top_k=top_k
+        )
+
+        saver = tf.train.Saver()
+        ckpt = tf.train.latest_checkpoint(os.path.join('models', model_name))
+        saver.restore(sess, ckpt)
+
+        print(conversation)
+
+        while True: 
+            message = None
+            while not message:
+                message = input("you: ")
+            conversation = conversation + "\nyou: " + message
+            conversation = conversation + "\nher: "
+            sys.stdout.write("her: ")
+            sys.stdout.flush()
+
+            #sys.stderr.write("************************"+conversation+"***********************")
+            #sys.stderr.flush()
+            
+            encoded_conversation = enc.encode(conversation)
+            result = sess.run(output, feed_dict={
+                context: [encoded_conversation]
+            })[:, len(encoded_conversation):]
+            text = enc.decode(result[0])
+            
+            #sys.stderr.write("=============="+text+"=================")
+            #sys.stderr.flush()
+
+            splits = text.split('\n')
+            #line = splits[1] if len(splits)>1 else splits[0]
+            #parts = line.split(': ')
+            #reply = parts[1] if len(parts)>1 else parts[0]
+            reply = splits[0]
+            sys.stdout.write(reply+'\n')
+            sys.stdout.flush()
+            conversation = conversation + reply
+
+if __name__ == '__main__':
+    fire.Fire(interact_model)
+


### PR DESCRIPTION
I'm experimenting with the 117M model, trying to build a simple interactive chat example. 
Results are _acceptable_:
![screenshot from 2019-02-24 18-06-38](https://user-images.githubusercontent.com/287189/53305323-0943d600-385f-11e9-8789-6255bb0df9a8.png)

However, I have a feeling my code has an error because when I try generating text with the other scripts (`src/generate_unconditional_samples.py` and `src/interactive_conditional_samples.py`), the output quality seems subjectively better. The approach I've taken is to keep the model in memory, and pass the whole conversation at each point, to generate the bot's reply. 

To try out the code on this branch, run: 
```
git remote add maraoz git@github.com:maraoz/gpt-2.git
git fetch maraoz
git checkout maraoz/master -b chat
python3 src/chat.py --seed=1337
```

Some open questions in case anyone (OpenAI team or community) wants to chime in:
- Is it correct to use the same model instance for the whole "chat session"? Or should I restore from a checkpoint before generating each new line?
- Is it correct to prompt the model with the whole conversation at each stage, or should I only send the new dialogue lines?
- Any other ideas on how to improve output quality? (tweaking `temperature`, `top_k`?)
