### PR TITLE
Add documentation for help flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,21 @@ There are various flags for controlling the samples:
 python3 src/generate_unconditional_samples.py --top_k 40 --temperature 0.7 | tee /tmp/samples
 ```
 
+To check flag descriptions, use:
+```
+python3 src/generate_unconditional_samples.py -- --help
+```
+
 ### Conditional sample generation
 
 To give the model custom prompts, you can use:
 ```
 python3 src/interactive_conditional_samples.py --top_k 40
+```
+
+To check flag descriptions, use:
+```
+python3 src/interactive_conditional_samples.py -- --help
 ```
 
 ## GPT-2 samples

--- a/src/generate_unconditional_samples.py
+++ b/src/generate_unconditional_samples.py
@@ -17,6 +17,26 @@ def sample_model(
     temperature=1,
     top_k=0,
 ):
+    """
+    Run the sample_model
+    :model_name=117M : String, which model to use
+    :seed=None : Integer seed for random number generators, fix seed to
+     reproduce results
+    :nsamples=0 : Number of samples to return, if 0, continues to
+     generate samples indefinately.
+    :batch_size=1 : Number of batches, model runs nsamples//batch_size
+     times, each batch run is independent of previous run.
+    :length=None : Number of tokens in generated text, if None (default), is
+     determined by model hyperparameters
+    :temperature=1 : Float value controlling randomness in boltzmann
+     distribution. Lower temperature results in less random completions. As the
+     temperature approaches zero, the model will become deterministic and
+     repetitive. Higher temperature results in more random completions.
+    :top_k=0 : Integer value controlling diversity. 1 means only 1 word is
+     considered for each step (token), resulting in deterministic completions,
+     while 40 means 40 words are considered at each step. 0 (default) is a
+     special setting meaning no restrictions. 40 generally is a good value.
+    """
     enc = encoder.get_encoder(model_name)
     hparams = model.default_hparams()
     with open(os.path.join('models', model_name, 'hparams.json')) as f:

--- a/src/interactive_conditional_samples.py
+++ b/src/interactive_conditional_samples.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import fire
 import json
 import os

--- a/src/interactive_conditional_samples.py
+++ b/src/interactive_conditional_samples.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import fire
 import json
 import os
@@ -17,6 +15,20 @@ def interact_model(
     temperature=1,
     top_k=0,
 ):
+    """
+    Interactively run the model
+    :model_name=117M : which model to use (default 117M)
+    :seed=None : Seed for random number generators, fix seed to reproduce
+     results
+    :nsamples=1 : number of samples to return
+    :batch_size=None : Number of batches, model runs nsamples//batch_size
+     times, each batch run is independent of previous run.
+    :length=None : Length of text to be returned, inclusive of punctuations
+     etc.
+    :temperature=1 : Controls degree of surprise in final output
+    :top_k=0 : Number of logits to be sampled, top_k=1 gives deterministic
+     output
+    """
     if batch_size is None:
         batch_size = 1
     assert nsamples % batch_size == 0

--- a/src/interactive_conditional_samples.py
+++ b/src/interactive_conditional_samples.py
@@ -10,24 +10,29 @@ def interact_model(
     model_name='117M',
     seed=None,
     nsamples=1,
-    batch_size=None,
+    batch_size=1,
     length=None,
     temperature=1,
     top_k=0,
 ):
     """
     Interactively run the model
-    :model_name=117M : which model to use (default 117M)
-    :seed=None : Seed for random number generators, fix seed to reproduce
+    :model_name=117M : String, which model to use
+    :seed=None : Integer seed for random number generators, fix seed to reproduce
      results
-    :nsamples=1 : number of samples to return
-    :batch_size=None : Number of batches, model runs nsamples//batch_size
+    :nsamples=1 : Number of samples to return
+    :batch_size=1 : Number of batches, model runs nsamples//batch_size
      times, each batch run is independent of previous run.
-    :length=None : Length of text to be returned, inclusive of punctuations
-     etc.
-    :temperature=1 : Controls degree of surprise in final output
-    :top_k=0 : Number of logits to be sampled, top_k=1 gives deterministic
-     output
+    :length=None : Number of tokens in generated text, if None (default), is
+     determined by model hyperparameters
+    :temperature=1 : Float value controlling randomness in boltzmann
+     distribution. Lower temperature results in less random completions. As the
+     temperature approaches zero, the model will become deterministic and
+     repetitive. Higher temperature results in more random completions.
+    :top_k=0 : Integer value controlling diversity. 1 means only 1 word is
+     considered for each step (token), resulting in deterministic completions,
+     while 40 means 40 words are considered at each step. 0 (default) is a
+     special setting meaning no restrictions. 40 generally is a good value.
     """
     if batch_size is None:
         batch_size = 1


### PR DESCRIPTION
Add documentation for help flags in unconditional and conditional sample generators and modify README with how to use help.
Also in interactive_conditional_samples.py, change default for batch_size to 1 instead of None to make it more readable, this does not impact execution in any way as it was already being performed in the code earlier:
`    if batch_size is None:
        batch_size = 1
`