### PR TITLE
Fix formatting issues in model output

### DIFF
--- a/src/generate_unconditional_samples.py
+++ b/src/generate_unconditional_samples.py
@@ -3,10 +3,14 @@
 import fire
 import json
 import os
+from string import printable
 import numpy as np
 import tensorflow as tf
 
 import model, sample, encoder
+
+def clean_output(s):
+    return ''.join(filter(lambda x: x in set(printable), s))
 
 def sample_model(
     model_name='117M',
@@ -68,8 +72,7 @@ def sample_model(
                 generated += batch_size
                 text = enc.decode(out[i])
                 print("=" * 40 + " SAMPLE " + str(generated) + " " + "=" * 40)
-                print(text)
+                print(clean_output(text))
 
 if __name__ == '__main__':
     fire.Fire(sample_model)
-

--- a/src/interactive_conditional_samples.py
+++ b/src/interactive_conditional_samples.py
@@ -3,10 +3,14 @@
 import fire
 import json
 import os
+from string import printable
 import numpy as np
 import tensorflow as tf
 
 import model, sample, encoder
+
+def clean_output(s):
+    return ''.join(filter(lambda x: x in set(printable), s))
 
 def interact_model(
     model_name='117M',
@@ -79,9 +83,8 @@ def interact_model(
                     generated += 1
                     text = enc.decode(out[i])
                     print("=" * 40 + " SAMPLE " + str(generated) + " " + "=" * 40)
-                    print(text)
+                    print(clean_output(text))
             print("=" * 80)
 
 if __name__ == '__main__':
     fire.Fire(interact_model)
-


### PR DESCRIPTION
There is an issue in the example scripts where some characters the model spits out can't be printed in certain contexts. This PR fixes the issue by filtering the model's output through `string.printable` before returning it.