### PR TITLE
Update mask_attn_weights to work with mixed precision training

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -85,7 +85,7 @@ def attn(x, scope, n_state, *, past, hparams):
         _, _, nd, ns = shape_list(w)
         b = attention_mask(nd, ns, dtype=w.dtype)
         b = tf.reshape(b, [1, 1, nd, ns])
-        w = w*b - tf.cast(1e10, w.dtype)*(1-b)
+        w = w*b - tf.cast(1e4, w.dtype)*(1-b)
         return w
 
     def multihead_attn(q, k, v):


### PR DESCRIPTION
Since we are multiplying by 1e10 originally to mask attention weights, when training in fp16, there is a gradient overflow. I've changed this to 1e4 to keep it within the range of fp16, and now it works in mixed precision. I've also tested with different seeds and the unconditional generation is unaffected. Please let me know if there anything else I need to do to complete this pull request. Thanks for releasing this model!