### PR TITLE
Update regex lib to 2018.01.10 from 2017.4.5.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fire>=0.1.3
-regex==2017.4.5
+regex==2018.1.10
 requests==2.21.0
 tqdm==4.31.1


### PR DESCRIPTION
Fixes `ERROR: spacy 2.0.18 has requirement regex==2018.01.10, but you'll have regex 2017.4.5 which is incompatible.`