### PR TITLE
Fix Tensorflow version

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -11,13 +11,13 @@ Then, follow instructions for either native or Docker installation.
 
 All steps can optionally be done in a virtual environment using tools such as `virtualenv` or `conda`.
 
-Install tensorflow 1.12 (with GPU support, if you have a GPU and want everything to run faster)
+Install tensorflow 1.13.1 (with GPU support, if you have a GPU and want everything to run faster)
 ```
-pip3 install tensorflow==1.12.0
+pip3 install tensorflow==1.13.1
 ```
 or
 ```
-pip3 install tensorflow-gpu==1.12.0
+pip3 install tensorflow-gpu==1.13.1
 ```
 
 Install other python packages:

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.12.0-py3
+FROM tensorflow/tensorflow:1.13.1-py3
 
 ENV LANG=C.UTF-8
 RUN mkdir /gpt-2

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.12.0-gpu-py3
+FROM tensorflow/tensorflow:1.13.1-gpu-py3
 
 # nvidia-docker 1.0
 LABEL com.nvidia.volumes.needed="nvidia_driver"


### PR DESCRIPTION
When running the example code in Docker, this error occurs. 

```
Traceback (most recent call last):
  File "src/interactive_conditional_samples.py", line 91, in <module>
    fire.Fire(interact_model)
  File "/usr/local/lib/python3.5/dist-packages/fire/core.py", line 138, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/usr/local/lib/python3.5/dist-packages/fire/core.py", line 471, in _Fire
    target=component.__name__)
  File "/usr/local/lib/python3.5/dist-packages/fire/core.py", line 675, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "src/interactive_conditional_samples.py", line 65, in interact_model
    temperature=temperature, top_k=top_k, top_p=top_p
  File "/gpt-2/src/sample.py", line 74, in sample_sequence
    past, prev, output = body(None, context, context)
  File "/gpt-2/src/sample.py", line 66, in body
    logits = top_p_logits(logits, p=top_p)
  File "/gpt-2/src/sample.py", line 28, in top_p_logits
    sorted_logits = tf.sort(logits, direction='DESCENDING', axis=-1)
AttributeError: module 'tensorflow' has no attribute 'sort'
```

Documentation, and Dockerfiles use Tensorflow 1.12, but sample.py uses a method not available in this version. This change updates to the next version that implements the missing method.