### PR TITLE
Fixed Dockerfile

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.12.0-py3
+FROM tensorflow/tensorflow:1.15.0-py3
 
 ENV LANG=C.UTF-8
 RUN mkdir /gpt-2

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:1.12.0-gpu-py3
+FROM tensorflow/tensorflow:1.15.0-gpu-py3
 
 # nvidia-docker 1.0
 LABEL com.nvidia.volumes.needed="nvidia_driver"


### PR DESCRIPTION
Dockerfile was failing because it used a version of TensorFlow which was too old.