### PR TITLE
batch size redudency

### DIFF
--- a/src/interactive_conditional_samples.py
+++ b/src/interactive_conditional_samples.py
@@ -40,8 +40,6 @@ def interact_model(
      (i.e. contains the <model_name> folder)
     """
     models_dir = os.path.expanduser(os.path.expandvars(models_dir))
-    if batch_size is None:
-        batch_size = 1
     assert nsamples % batch_size == 0
 
     enc = encoder.get_encoder(model_name, models_dir)


### PR DESCRIPTION
    if batch_size is None:
        batch_size = 1

Unnecessary batch_size = 1 is set as default what's the point of this? Why not just catch error or something seems more useful.