### PR TITLE
Fix minor comment typo in encoder.py

### DIFF
--- a/src/encoder.py
+++ b/src/encoder.py
@@ -49,7 +49,7 @@ class Encoder:
         self.bpe_ranks = dict(zip(bpe_merges, range(len(bpe_merges))))
         self.cache = {}
 
-        # Should haved added re.IGNORECASE so BPE merges can happen for capitalized versions of contractions
+        # Should have added re.IGNORECASE so BPE merges can happen for capitalized versions of contractions
         self.pat = re.compile(r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""")
 
     def bpe(self, token):


### PR DESCRIPTION
Replaced "haved" with "have" for grammatical correctness to improve readability of the comment.